### PR TITLE
Memory leak fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .DS_Store
+*.drawio

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ I will need to add a TON of error handling once the hashtable works as expected.
 Rather than use GDB to debug, I will switch over to LLDB since it seems to be more compatible with Apple's suite of technologies.
 
 - As of Dec 31st, the allocation of memory for a hashtable is done all on the stack and is freed using the free_hashtable method. I am attempting to create a deep copy of the string key copy I am holding but am having buffer overflow issues I am having trouble understanding which is why I need to learn how to use lldb to look into memory what is being written where and why.
+
+# Cool GBD tips and tricks
+
+Use @ operand to print contiguous memory (in an array format)
+
+p (\*(\*map).val)@16

--- a/README.md
+++ b/README.md
@@ -5,3 +5,25 @@ Implementation of a HashTable in C
 # build c executable
 
 `gcc -std=c99 -g -o build/main ./main.c ./hashtable.c`
+
+# To-Do
+
+I think I need to fix where I initialize the hashtable. Rn this is being done on the stack with the actual arrays initialized on the heap. I should be allocating memory for the whole hashtable on the heap with nothing on the stack.
+
+- This can be achieved by having the function return a hashtable address that will be given to a hashtable pointer
+
+With the constructor finished, I also need to create a destructor that will free all allocated memory
+
+- I can also tackle allocating memory to the str_key at this stage or forget it for the time being since it does not add to the logic of the hashtable
+
+Next I need to switch from creating a new hashtable when resizing to just creating a new array for the key, value, and str_key.
+
+- To be more specific, if I have a constructor and destructor that workd exactly as expected, I need to figure out if using the const/destruct is better or using newly allocated arrays is better
+
+Once the allocation is done better and all on the heap, I can debug some more
+
+I will need to add a TON of error handling once the hashtable works as expected. That way using it in the wrong way does not crash or break an application.
+
+Rather than use GDB to debug, I will switch over to LLDB since it seems to be more compatible with Apple's suite of technologies.
+
+- As of Dec 31st, the allocation of memory for a hashtable is done all on the stack and is freed using the free_hashtable method. I am attempting to create a deep copy of the string key copy I am holding but am having buffer overflow issues I am having trouble understanding which is why I need to learn how to use lldb to look into memory what is being written where and why.

--- a/hashtable.c
+++ b/hashtable.c
@@ -3,7 +3,7 @@
 
 #include "hashtable.h"
 
-#define DEFAULT_SIZE 16
+#define DEFAULT_SIZE 8
 
 /**
  * djb2 hash function
@@ -31,13 +31,20 @@ char *copy_string(char *str)
     size++;
   }
 
-  char *copy = malloc((size * sizeof(char)) + 1);
+  printf("size is %d\n", size);
+
+  char *copy = calloc(5, sizeof(char));
+  printf("before\n");
+  printf("string %s\n", str);
   for (int i = 0; i < size; i++)
   {
+    printf("malloc");
     *(copy + i) = *(str + i);
   }
 
   *(copy + size) = '\0';
+
+  printf("new string is %s\n", copy);
 
   return copy;
 }
@@ -139,11 +146,27 @@ void resize_hashtable(Hashtable *map)
 Hashtable *initialize_hashtable()
 {
   Hashtable *map = malloc(sizeof(Hashtable));
+  printf("Size is %d\n\n", sizeof(Hashtable));
+  printf("Address of map value is %18p\n", &(map->val));
+  printf("Address of map key is %20p\n", &(map->key));
+  printf("Address of map string key is %13p\n", &(map->str_key));
+  printf("Address of map size is %19p\n", &(map->size));
+  printf("Address of map count is %18p\n\n", &(map->count));
 
-  map->val = (int *)calloc(DEFAULT_SIZE * sizeof(int), 0);
+  map->val = calloc(DEFAULT_SIZE, sizeof(int));
   // Using calloc here instead of malloc breaks a lot of stuff and I should figure out why
-  map->key = malloc(DEFAULT_SIZE * sizeof(unsigned long));
+  map->key = calloc(DEFAULT_SIZE, sizeof(unsigned long));
   map->str_key = malloc(DEFAULT_SIZE * sizeof(char *));
+
+  printf("Address of first map value is %18p\n", map->val);
+  printf("Address of first map key is %20p\n", map->key);
+  printf("Address of first map string key is %13p\n\n", map->str_key);
+
+  // We need to initialize the pointers to string to NULL
+  for (int i = 0; i < DEFAULT_SIZE; i++)
+  {
+    *(map->str_key + (2 * i)) = NULL;
+  }
   map->size = DEFAULT_SIZE;
   map->count = 0;
 
@@ -157,6 +180,7 @@ Hashtable *initialize_hashtable()
 
 void free_hashtable(Hashtable *map)
 {
+  printf("Freeing memory\n");
   free(map->val);
   map->val = NULL;
 
@@ -168,8 +192,8 @@ void free_hashtable(Hashtable *map)
     if (*(map->str_key + (2 * i)) != NULL)
     {
       free(*(map->str_key + (2 * i)));
+      *(map->str_key + (2 * i)) = NULL;
     }
-    *(map->str_key + (2 * i)) = NULL;
   }
   free(map->str_key);
   map->str_key = NULL;
@@ -184,7 +208,7 @@ void free_hashtable(Hashtable *map)
 
   if (map != NULL)
   {
-    printf("Failed to free hashtable memory\n");
+    printf("Failed to free hashtable\n");
   }
 }
 
@@ -192,16 +216,16 @@ void add_to_hashtable(Hashtable *map, char *key)
 {
   // Calculate hash of key
   unsigned long h = hash(key);
-
   // Use linear probing to iterate until i does not create a collision
-  int i;
+
+  int i = 0;
   while ((i = collision(map, h)) == -1)
   {
     h++;
   }
 
   // Increment by 1
-  *((int *)(map->val) + i) += 1;
+  *((map->val) + i) += 1;
 
   // Store key
   *((map->key) + i) = h;
@@ -211,11 +235,11 @@ void add_to_hashtable(Hashtable *map, char *key)
   *((map->str_key) + (2 * i)) = copy_string(key);
 
   // Check for 33% capicity. If over, double the size of the hashtable
-  if (((map->count * 100) / map->size) > 33)
-  {
-    resize_hashtable(map);
-    printf("Size is now %d.\n", map->size);
-  }
+  // if (((map->count * 100) / map->size) > 33)
+  // {
+  //   resize_hashtable(map);
+  //   printf("Size is now %d.\n", map->size);
+  // }
 }
 
 int search_hashtable(Hashtable *map, char *key)
@@ -271,7 +295,7 @@ void print_hashtable(Hashtable *map)
   {
     // if ((*((int *)(map->val) + i) != 0) && (*((int *)(map->val) + i) != -1))
     // {
-    printf("index: %4d  ||  key: %20lu  || str_key: %16s  ||  value: %4d\n", i, *((map->key) + i), *((map->str_key) + (2 * i)), *((int *)(map->val) + i));
+    printf("index: %4d  ||  key: %20lu  || str_key: %16s  ||  value: %4d\n", i, *((map->key) + i), *((map->str_key) + (2 * i)), *((map->val) + i));
     // }
   }
 }

--- a/hashtable.c
+++ b/hashtable.c
@@ -4,7 +4,78 @@
 #include "hashtable.h"
 
 #define DEFAULT_SIZE 16
-#define RESIZE_PERCENTAGE 33
+#define RESIZE_PERCENTAGE 70
+
+/**
+ * Initialize hashtable
+ */
+Hashtable *initialize_hashtable()
+{
+  Hashtable *map = malloc(sizeof(Hashtable));
+  printf("\nAddress of map value is %18p\n", &(map->val));
+  printf("Address of map key is %20p\n", &(map->key));
+  printf("Address of map string key is %13p\n", &(map->str_key));
+  printf("Address of map size is %19p\n", &(map->size));
+  printf("Address of map count is %18p\n\n", &(map->count));
+
+  map->val = (int *)calloc(DEFAULT_SIZE, sizeof(int));
+  // Using calloc here instead of malloc breaks a lot of stuff and I should figure out why
+  map->key = (unsigned long *)calloc(DEFAULT_SIZE, sizeof(unsigned long));
+  map->str_key = (char **)malloc(DEFAULT_SIZE * sizeof(char *));
+
+  printf("Address of first map value is %18p\n", map->val);
+  printf("Address of first map key is %20p\n", map->key);
+  printf("Address of first map string key is %13p\n\n", map->str_key);
+
+  printf("Pointer-to-pointer address is: %p\n", map->str_key);
+  printf("Pointer-to-pointer second address is: %p\n", (map->str_key + 1));
+  printf("Pointer-to-pointer second address is: %p\n", ((map->str_key) + 1));
+
+  // We need to initialize the pointers to string to NULL
+  for (int i = 0; i < DEFAULT_SIZE; i++)
+  {
+    *((map->str_key) + i) = NULL;
+  }
+
+  map->size = DEFAULT_SIZE;
+  map->count = 0;
+
+  if (map->val == NULL || map->key == NULL || map->str_key == NULL)
+  {
+    printf("Failed to initialize hashtable\n");
+  }
+
+  return map;
+}
+
+/**
+ * Free up allocated memory from hashtable
+ */
+void free_hashtable(Hashtable **map)
+{
+  printf("Freeing memory!\n");
+  free((*map)->val);
+  (*map)->val = NULL;
+
+  free((*map)->key);
+  (*map)->key = NULL;
+
+  free((*map)->str_key);
+  (*map)->str_key = NULL;
+
+  if ((*map)->val != NULL || (*map)->key != NULL || (*map)->str_key != NULL)
+  {
+    printf("Failed to free hashtable memory\n");
+  }
+
+  free((*map));
+  (*map) = NULL;
+
+  if ((*map) != NULL)
+  {
+    printf("Failed to free hashtable\n");
+  }
+}
 
 /**
  * djb2 hash function
@@ -55,7 +126,7 @@ int collision(Hashtable *map, unsigned long h)
 int search_collision(Hashtable *map, unsigned long h)
 {
   // Get index from hash of key
-  int i = (int)(h % (unsigned long)(map->size));
+  int i = (int)(h % (map->size));
 
   // Compare stored hash key to curernt hash at index i
   if (*((map->key) + i) == h)
@@ -68,33 +139,26 @@ int search_collision(Hashtable *map, unsigned long h)
   }
   else
   {
-    printf("Collision detected for hash %lu\n", h);
+    printf("Collision detected for hash %lu. Returning -1\n", h);
     return -1;
   }
 }
 
-Hashtable *initialize_hashtable_with_size(int size)
+/**
+ * Helper function for hashtable resize
+ */
+Hashtable *initialize_hashtable_for_resize(int size)
 {
   Hashtable *map = malloc(sizeof(Hashtable));
-  // printf("\nAddress of map value is %18p\n", &(map->val));
-  // printf("Address of map key is %20p\n", &(map->key));
-  // printf("Address of map string key is %13p\n", &(map->str_key));
-  // printf("Address of map size is %19p\n", &(map->size));
-  // printf("Address of map count is %18p\n\n", &(map->count));
 
-  map->val = calloc(size, sizeof(int));
-  // Using calloc here instead of malloc breaks a lot of stuff and I should figure out why
-  map->key = calloc(size, sizeof(unsigned long));
+  map->val = (int *)calloc(size, sizeof(int));
+  map->key = (unsigned long *)calloc(size, sizeof(unsigned long));
   map->str_key = (char **)malloc(size * sizeof(char *));
-
-  // printf("Address of first map value is %18p\n", map->val);
-  // printf("Address of first map key is %20p\n", map->key);
-  // printf("Address of first map string key is %13p\n\n", map->str_key);
 
   // We need to initialize the pointers to string to NULL
   for (int i = 0; i < size; i++)
   {
-    *((map->str_key) + (2 * i)) = NULL;
+    *((map->str_key) + i) = NULL;
   }
 
   map->size = size;
@@ -109,110 +173,9 @@ Hashtable *initialize_hashtable_with_size(int size)
 }
 
 /**
- * Double size of hashtable
+ * Helper function for hashtable resize
  */
-void resize_hashtable(Hashtable *map)
-{
-  Hashtable *new_map = initialize_hashtable_with_size(map->size * 2);
-
-  for (int i = 0; i < map->size; i++)
-  {
-    if ((*((int *)(map->val) + i) != 0) && (*((int *)(map->val) + i) != -1))
-    {
-      unsigned long h = *((map->key) + i);
-      int j;
-      while ((j = collision(new_map, h)) == -1)
-      {
-        h++;
-      }
-
-      // Copy over values
-      *((int *)(new_map->val) + j) = *((int *)(map->val) + i);
-
-      // Copy over hash keys
-      *((new_map->key) + j) = *((unsigned long *)(map->key) + i);
-
-      // Copy over string keys
-      *((new_map->str_key) + (2 * j)) = *((map->str_key) + (2 * i));
-    }
-  }
-
-  // Free old memory
-  free_hashtable(map);
-
-  map = new_map;
-}
-
-Hashtable *initialize_hashtable()
-{
-  Hashtable *map = malloc(sizeof(Hashtable));
-  printf("\nAddress of map value is %18p\n", &(map->val));
-  printf("Address of map key is %20p\n", &(map->key));
-  printf("Address of map string key is %13p\n", &(map->str_key));
-  printf("Address of map size is %19p\n", &(map->size));
-  printf("Address of map count is %18p\n\n", &(map->count));
-
-  map->val = calloc(DEFAULT_SIZE, sizeof(int));
-  // Using calloc here instead of malloc breaks a lot of stuff and I should figure out why
-  map->key = calloc(DEFAULT_SIZE, sizeof(unsigned long));
-  map->str_key = (char **)malloc(DEFAULT_SIZE * sizeof(char *));
-
-  printf("Address of first map value is %18p\n", map->val);
-  printf("Address of first map key is %20p\n", map->key);
-  printf("Address of first map string key is %13p\n\n", map->str_key);
-
-  // We need to initialize the pointers to string to NULL
-  for (int i = 0; i < DEFAULT_SIZE; i++)
-  {
-    *((map->str_key) + (2 * i)) = NULL;
-  }
-
-  map->size = DEFAULT_SIZE;
-  map->count = 0;
-
-  if (map->val == NULL || map->key == NULL || map->str_key == NULL)
-  {
-    printf("Failed to initialize hashtable\n");
-  }
-
-  return map;
-}
-
-void free_hashtable(Hashtable *map)
-{
-  printf("Freeing memory\n");
-  free(map->val);
-  map->val = NULL;
-
-  free(map->key);
-  map->key = NULL;
-
-  for (int i = 0; i < map->size; i++)
-  {
-    if (*(map->str_key + (2 * i)) != NULL)
-    {
-      free(*(map->str_key + (2 * i)));
-      *(map->str_key + (2 * i)) = NULL;
-    }
-  }
-  free(map->str_key);
-  map->str_key = NULL;
-
-  if (map->val != NULL || map->key != NULL || map->str_key != NULL)
-  {
-    printf("Failed to free hashtable memory\n");
-  }
-
-  free(map);
-  map = NULL;
-
-  if (map != NULL)
-  {
-    printf("Failed to free hashtable\n");
-  }
-}
-
-void add_to_hashtable(Hashtable *map, char *key)
+void add_to_hashtable_for_resize(Hashtable *map, char *key, int val)
 {
   // Calculate hash of key
   unsigned long h = hash(key);
@@ -224,21 +187,63 @@ void add_to_hashtable(Hashtable *map, char *key)
     h++;
   }
 
-  // Increment by 1
-  *((map->val) + i) += 1;
+  // Copy previous value
+  *((map->val) + i) = val;
 
   // Store key
   *((map->key) + i) = h;
 
   // Store string key
-  // We times i by 2 because the size of a pointer is 8 bytes
-  *((map->str_key) + (2 * i)) = key;
+  *((map->str_key) + i) = key;
+}
+
+/**
+ * Double size of hashtable
+ */
+void resize_hashtable(Hashtable **map)
+{
+  Hashtable *new_map = initialize_hashtable_for_resize((*map)->size * 2);
+
+  for (int i = 0; i < (*map)->size; i++)
+  {
+    if ((*(((*map)->val) + i) != 0) && (*(((*map)->val) + i) != -1))
+    {
+      add_to_hashtable_for_resize(new_map, *(((*map)->str_key) + i), *(((*map)->val) + i));
+    }
+  }
+
+  // Free old memory
+  free_hashtable(map);
+
+  (*map) = new_map;
+}
+
+void add_to_hashtable(Hashtable **map, char *key)
+{
+  // Calculate hash of key
+  unsigned long h = hash(key);
+  // Use linear probing to iterate until i does not create a collision
+
+  int i = 0;
+  while ((i = collision((*map), h)) == -1)
+  {
+    h++;
+  }
+
+  // Increment by 1
+  *(((*map)->val) + i) += 1;
+
+  // Store key
+  *(((*map)->key) + i) = h;
+
+  // Store string key
+  *(((*map)->str_key) + i) = key;
 
   // Check for 33% capicity. If over, double the size of the hashtable
-  if (((map->count * 100) / map->size) > RESIZE_PERCENTAGE)
+  if ((((*map)->count * 100) / (*map)->size) > RESIZE_PERCENTAGE)
   {
     resize_hashtable(map);
-    printf("Size is now %d.\n", map->size);
+    printf("Size is now %d.\n", (*map)->size);
   }
 }
 
@@ -260,7 +265,7 @@ int search_hashtable(Hashtable *map, char *key)
   }
   else
   {
-    return *((int *)(map->val) + i);
+    return *((map->val) + i);
   }
 }
 
@@ -283,7 +288,7 @@ void remove_from_hashtable(Hashtable *map, char *key)
   {
     *((int *)(map->val) + i) = -1;
     *((map->key) + i) = 0;
-    *((map->str_key) + (2 * i)) = NULL;
+    *((map->str_key) + i) = NULL;
 
     map->count -= 1;
   }
@@ -295,7 +300,7 @@ void print_hashtable(Hashtable *map)
   {
     // if ((*((int *)(map->val) + i) != 0) && (*((int *)(map->val) + i) != -1))
     // {
-    printf("index: %4d  ||  key: %20lu  || str_key: %16s  ||  value: %4d\n", i, *((map->key) + i), *((map->str_key) + (2 * i)), *((map->val) + i));
+    printf("index: %4d  ||  key: %20lu  || str_key: %16s  ||  value: %4d\n", i, *((map->key) + i), *((map->str_key) + i), *((map->val) + i));
     // }
   }
 }

--- a/hashtable.h
+++ b/hashtable.h
@@ -28,7 +28,7 @@
 
 typedef struct Hashtable
 {
-  void *val;          // key value pair
+  int *val;           // key value pair
   unsigned long *key; // hash key pair (used to check for collision)
   char **str_key;     // string key
   int size;           // size of hashtable

--- a/hashtable.h
+++ b/hashtable.h
@@ -43,12 +43,12 @@ Hashtable *initialize_hashtable();
 /**
  * Free allocated space to hashtable
  */
-void free_hashtable(Hashtable *map);
+void free_hashtable(Hashtable **map);
 
 /**
  * Treat hashtable as a Counter and add 1 to current count of key
  */
-void add_to_hashtable(Hashtable *map, char *key);
+void add_to_hashtable(Hashtable **map, char *key);
 
 /**
  * Return the value of a key/value pair. Returns -1 if no key was found in the hashtable

--- a/hashtable.h
+++ b/hashtable.h
@@ -30,13 +30,13 @@ typedef struct Hashtable
 {
   void *val;          // key value pair
   unsigned long *key; // hash key pair (used to check for collision)
-  void *str_key;      // string key
+  char **str_key;     // string key
   int size;           // size of hashtable
   int count;          // current number of items in hashtable
 } Hashtable;
 
 /**
- * Initializes void pointer of type Hashtable
+ * Initializes pointer of type Hashtable
  */
 Hashtable *initialize_hashtable();
 
@@ -48,17 +48,17 @@ void free_hashtable(Hashtable *map);
 /**
  * Treat hashtable as a Counter and add 1 to current count of key
  */
-void add_to_hashtable(Hashtable *map, void *key);
+void add_to_hashtable(Hashtable *map, char *key);
 
 /**
  * Return the value of a key/value pair. Returns -1 if no key was found in the hashtable
  */
-int search_hashtable(Hashtable *map, void *key);
+int search_hashtable(Hashtable *map, char *key);
 
 /**
  * Remove the a key from a hashtable if it exists
  */
-void remove_from_hashtable(Hashtable *map, void *key);
+void remove_from_hashtable(Hashtable *map, char *key);
 
 /**
  * Print the contents of the hashtable

--- a/main.c
+++ b/main.c
@@ -17,16 +17,16 @@ int main()
   Hashtable *map = initialize_hashtable();
 
   add_to_hashtable(map, "sport");
-  // add_to_hashtable(map, "Sport");
-  // add_to_hashtable(map, "sport");
-  // add_to_hashtable(map, "train");
-  // add_to_hashtable(map, "Hello World!");
-  // add_to_hashtable(map, "Hello World!");
-  // add_to_hashtable(map, "Hello World!");
-  // add_to_hashtable(map, "Hello World!");
-  // add_to_hashtable(map, "Hello World!");
-  // add_to_hashtable(map, "Hello World");
-  // add_to_hashtable(map, "Apple");
+  add_to_hashtable(map, "Sport");
+  add_to_hashtable(map, "sport");
+  add_to_hashtable(map, "train");
+  add_to_hashtable(map, "Hello World!");
+  add_to_hashtable(map, "Hello World!");
+  add_to_hashtable(map, "Hello World!");
+  add_to_hashtable(map, "Hello World!");
+  add_to_hashtable(map, "Hello World!");
+  add_to_hashtable(map, "Hello World");
+  add_to_hashtable(map, "Apple");
 
   print_hashtable(map);
 

--- a/main.c
+++ b/main.c
@@ -16,51 +16,55 @@ int main()
    */
   Hashtable *map = initialize_hashtable();
 
-  add_to_hashtable(map, "sport");
-  add_to_hashtable(map, "Sport");
-  add_to_hashtable(map, "sport");
-  add_to_hashtable(map, "train");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World");
-  add_to_hashtable(map, "Apple");
+  add_to_hashtable(&map, "sport");
+  add_to_hashtable(&map, "Sport");
+  add_to_hashtable(&map, "sport");
+  add_to_hashtable(&map, "train");
+  add_to_hashtable(&map, "Hello World!");
+  add_to_hashtable(&map, "Hello World!");
+  add_to_hashtable(&map, "Hello World!");
+  add_to_hashtable(&map, "Hello World!");
+  add_to_hashtable(&map, "Hello World!");
+  add_to_hashtable(&map, "Hello World");
+  add_to_hashtable(&map, "Apple");
+
+  char *key = "Hello World!";
+  int n = search_hashtable(map, key);
+  if (n != -1)
+  {
+    printf("Key \"%s\" has a value of %d\n", key, n);
+  }
+
+  char *key1 = "Hello Worl";
+  int n1 = search_hashtable(map, key1);
+  if (n1 != -1)
+  {
+    printf("Key \"%s\" has a value of %d\n", key1, n1);
+  }
+
+  int c = search_hashtable(map, "Sport");
+  if (c != -1)
+  {
+    printf("Key \"%s\" has a value of %d\n", "Sport", c);
+  }
+
+  key = "sport";
+  remove_from_hashtable(map, key);
+  print_hashtable(map);
+
+  add_to_hashtable(&map, "tree");
+  add_to_hashtable(&map, "Francais");
+  add_to_hashtable(&map, "Fourmi");
+  add_to_hashtable(&map, "Joe Dassin");
+  add_to_hashtable(&map, "Duran Duran");
+  add_to_hashtable(&map, "Queen");
+  add_to_hashtable(&map, "View to a Kill");
+  add_to_hashtable(&map, "Rio");
+  add_to_hashtable(&map, "Hungry");
 
   print_hashtable(map);
 
-  // char *key = "Hello World!";
-  // int n = search_hashtable(map, key);
-  // if (n != -1)
-  // {
-  //   printf("Key \"%s\" has a value of %d\n", key, n);
-  // }
-
-  /**
-   * An intersting bug occurs here where just inputing the string "Hello World" as the
-   * input causes a "No key found error" even if the key "Hello World" can be found.
-   * This is probably caused by a key of type char * being different than the default type
-   * given to the c string "Hello World".
-   */
-  // int c = search_hashtable(map, (char *)"Hello world");
-
-  // key = "sport";
-  // remove_from_hashtable(map, key);
-
-  // add_to_hashtable(map, "tree");
-  // add_to_hashtable(map, "Francais");
-  // add_to_hashtable(map, "Fourmi");
-  // add_to_hashtable(map, "Joe Dassin");
-  // add_to_hashtable(map, "Duran Duran");
-  // add_to_hashtable(map, "Queen");
-  // add_to_hashtable(map, "View to a Kill");
-  // add_to_hashtable(map, "Rio");
-  // add_to_hashtable(map, "Hungry");
-
-  // print_hashtable(map);
-
-  free_hashtable(map);
+  free_hashtable(&map);
   printf("\n");
   return 0;
 }

--- a/main.c
+++ b/main.c
@@ -17,16 +17,16 @@ int main()
   Hashtable *map = initialize_hashtable();
 
   add_to_hashtable(map, "sport");
-  add_to_hashtable(map, "Sport");
-  add_to_hashtable(map, "sport");
-  add_to_hashtable(map, "train");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World!");
-  add_to_hashtable(map, "Hello World");
+  // add_to_hashtable(map, "Sport");
+  // add_to_hashtable(map, "sport");
+  // add_to_hashtable(map, "train");
+  // add_to_hashtable(map, "Hello World!");
+  // add_to_hashtable(map, "Hello World!");
+  // add_to_hashtable(map, "Hello World!");
+  // add_to_hashtable(map, "Hello World!");
+  // add_to_hashtable(map, "Hello World!");
+  // add_to_hashtable(map, "Hello World");
+  // add_to_hashtable(map, "Apple");
 
   print_hashtable(map);
 
@@ -47,7 +47,6 @@ int main()
 
   // key = "sport";
   // remove_from_hashtable(map, key);
-  // print_hashtable(map);
 
   // add_to_hashtable(map, "tree");
   // add_to_hashtable(map, "Francais");
@@ -59,7 +58,7 @@ int main()
   // add_to_hashtable(map, "Rio");
   // add_to_hashtable(map, "Hungry");
 
-  print_hashtable(map);
+  // print_hashtable(map);
 
   free_hashtable(map);
   printf("\n");


### PR DESCRIPTION
Weird bugs were being cause by two major flaws.

1. Pointer arithmetic for the value and key were being done in increments of 1 while pointer arithmetic for the str_key was being done in increments of 2. This was due to a lack of understanding of how the compiler handles pointer arithmetic as supplying the type is enough for the compiler to know whether it should jump 1, 2, 4, or 8 bytes depending on the data type being accessed.

2. Using a pointer to edit a value within a function works as expected, however changing the address a pointer points to does not work since the pointer itself is passed by value. I did not make this distinction which caused more issues when the size of the hashtable needed resizing or freeing up memory at the end of the program. This was a simple fix and just required functions that could edit the address a pointer is pointing too to take in a pointer to a pointer as a parameter.